### PR TITLE
Add support for `max_product_length`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added a max_product_length option
 
 ## [0.6.0] - 2022-12-05
 ### Added

--- a/src/ispcr/__init__.py
+++ b/src/ispcr/__init__.py
@@ -2,7 +2,11 @@ import re
 from typing import Union
 
 from ispcr.FastaSequence import FastaSequence
-from ispcr.utils import read_sequences_from_file, reverse_complement
+from ispcr.utils import (
+    desired_product_size,
+    read_sequences_from_file,
+    reverse_complement,
+)
 
 
 def get_pcr_product(
@@ -10,6 +14,7 @@ def get_pcr_product(
     forward_primer: FastaSequence,
     reverse_primer: FastaSequence,
     min_product_length: Union[int, None] = None,
+    max_product_length: Union[int, None] = None,
 ) -> str:
     """Returns the products amplified by a pair of primers against a single sequence.
 
@@ -70,7 +75,11 @@ def get_pcr_product(
                 forward_match + reverse_match + len(reverse_primer)
             )  # This is the end in the original sequence
             product_length = len(product)
-            if min_product_length is not None and product_length < min_product_length:
+            # if min_product_length is not None and product_length < min_product_length:
+            #     continue
+            if not desired_product_size(
+                product_length, min_product_length, max_product_length
+            ):
                 continue
 
             product_line = f"{forward_primer.header}\t{reverse_primer.header}\t{start}\t{end}\t{product_length}\t{product}"
@@ -79,7 +88,10 @@ def get_pcr_product(
 
 
 def find_pcr_product(
-    primer_file: str, sequence_file: str, min_product_length: Union[int, None] = None
+    primer_file: str,
+    sequence_file: str,
+    min_product_length: Union[int, None] = None,
+    max_product_length: Union[int, None] = None,
 ) -> str:
     """Returns all the products amplified by a set of primers in all sequences in a fasta file.
 
@@ -126,6 +138,7 @@ def find_pcr_product(
             forward_primer=forward_primer,
             reverse_primer=reverse_primer,
             min_product_length=min_product_length,
+            max_product_length=max_product_length,
         )
         products.append(new_products)
     return "\n".join(products)

--- a/src/ispcr/utils.py
+++ b/src/ispcr/utils.py
@@ -2,9 +2,50 @@
 This module contains various utilities used during in silico PCR.
 """
 
-from typing import Iterator, List, TextIO
+from typing import Iterator, List, TextIO, Union
 
 from ispcr.FastaSequence import FastaSequence
+
+
+def desired_product_size(
+    potential_product_length: int,
+    min_product_length: Union[int, None] = None,
+    max_product_length: Union[int, None] = None,
+) -> bool:
+    """Determines if a potential product's size is in the user's desired product range.
+
+    Inputs
+    potential_product_length - int
+        The length of the potential product
+    min_product_length: int | None
+        The minimum product size the user will accept. If None, there is no lower limit.
+    max_product_length: int | None
+        The maximum product size the user will accept. If None, there is no lower limit.
+
+    Outputs
+    A boolean for whether the product length is between the min and max product length.
+
+    Example
+    desired_product_size(100, 75, 125)
+    True
+    desired_product_size(200, 75, 125)
+    False
+    """
+
+    if min_product_length is None:
+        if max_product_length is None:
+            return True
+        else:
+            return potential_product_length <= max_product_length
+    else:
+        if max_product_length is None:
+            return min_product_length <= potential_product_length
+        else:
+            if max_product_length < min_product_length:
+                raise ValueError(
+                    "min_product_length cannot be larger than max_product_length"
+                )
+            return min_product_length <= potential_product_length <= max_product_length
 
 
 def reverse_complement(dna_string: str) -> str:

--- a/tests/test_Product_functions.py
+++ b/tests/test_Product_functions.py
@@ -18,6 +18,12 @@ class TestGetPCRPRoduct:
         sequence = FastaSequence("test_sequence", "GGAGCATGCTATGTCGTAGCTGATGCAATTA")
         yield sequence
 
+    @pytest.fixture(scope="class")
+    def medium_sequence_1(self) -> Iterator[FastaSequence]:
+        seq_string = "AAAACCCACCCAAAAAATATTCTTTTGCATCCACTGTCAACTTTTCACAGAAACCCATTAAGTCAGGATCCTTAAGAGTTTCCGAGTGTTCATCTGCTGATATTCCAACAACAAACTCTACCGAGTGTCTGAATTTGCTGCTTGAAAAGAGAGGAGCTTCATCGAGTCAAAACTGTTGGAGAAAGATTTCTCTTGAAGATCTTTTCTGTTCCACTTCAAACCTTCCTTCCCCTACTAAAGGGAATCTCCCAATTATTGCCGACGCTGGTGACCATGGGATTTTATCTTTCAAAGTTTCTGACCTGAAAGAAGATATACCCTCGCAAATATCGACGGCTAAGGAAGAGTCCTTCAGTGGTAATGAAGAAGAAGAAGAAGAAGAAGGTGATGACGATGATAAGATAACCCTTCAGGATTTTGTTTGTAATGAAAAGAACCAAAAAGAAATGGGTGAACAAAGAAATGACGTAAGCTCGTCTTCTTGGGTACAAACTGAGCTGTTGTTTCTTCTCCTAAAGGGAAGTATCGGGAGTAATGATACTCAAACAACACTGAGAAAACCAACCCTGTTTCTGATTCCACATTA"
+        sequence = FastaSequence("medium_test_sequence", seq_string)
+        yield sequence
+
     def test_simple_sequence(
         self, primers: List[FastaSequence], small_sequence_1: FastaSequence
     ) -> None:
@@ -49,6 +55,35 @@ class TestGetPCRPRoduct:
 
         assert expected_results == actual_results
 
+    def test_maximum_product_length(
+        self, primers: List[FastaSequence], medium_sequence_1: FastaSequence
+    ) -> None:
+        expected_results = "test_forward\ttest_reverse\t177\t255\t78\tGGAGAAAGATTTCTCTTGAAGATCTTTTCTGTTCCACTTCAAACCTTCCTTCCCCTACTAAAGGGAATCTCCCAATTA\ntest_forward\ttest_reverse\t528\t586\t58\tGGAGTAATGATACTCAAACAACACTGAGAAAACCAACCCTGTTTCTGATTCCACATTA"
+        forward_primer, reverse_primer = primers
+        actual_results = get_pcr_product(
+            sequence=medium_sequence_1,
+            forward_primer=forward_primer,
+            reverse_primer=reverse_primer,
+            max_product_length=100,
+        )
+
+        assert expected_results == actual_results
+
+    def test_product_length_range(
+        self, primers: List[FastaSequence], medium_sequence_1: FastaSequence
+    ) -> None:
+        expected_results = "test_forward\ttest_reverse\t177\t255\t78\tGGAGAAAGATTTCTCTTGAAGATCTTTTCTGTTCCACTTCAAACCTTCCTTCCCCTACTAAAGGGAATCTCCCAATTA"
+        forward_primer, reverse_primer = primers
+        actual_results = get_pcr_product(
+            sequence=medium_sequence_1,
+            forward_primer=forward_primer,
+            reverse_primer=reverse_primer,
+            min_product_length=75,
+            max_product_length=100,
+        )
+
+        assert expected_results == actual_results
+
 
 class TestFindProduct:
     def test_simple_sequence(self) -> None:
@@ -61,11 +96,31 @@ class TestFindProduct:
         assert expected_result == actual_result
 
     def test_min_product_length(self) -> None:
-        expected_result = "forward_primer.f\treverse_primer.r\t152\t586\t434\tGGAGCTTCATCGAGTCAAAACTGTTGGAGAAAGATTTCTCTTGAAGATCTTTTCTGTTCCACTTCAAACCTTCCTTCCCCTACTAAAGGGAATCTCCCAATTATTGCCGACGCTGGTGACCATGGGATTTTATCTTTCAAAGTTTCTGACCTGAAAGAAGATATACCCTCGCAAATATCGACGGCTAAGGAAGAGTCCTTCAGTGGTAATGAAGAAGAAGAAGAAGAAGAAGGTGATGACGATGATAAGATAACCCTTCAGGATTTTGTTTGTAATGAAAAGAACCAAAAAGAAATGGGTGAACAAAGAAATGACGTAAGCTCGTCTTCTTGGGTACAAACTGAGCTGTTGTTTCTTCTCCTAAAGGGAAGTATCGGGAGTAATGATACTCAAACAACACTGAGAAAACCAACCCTGTTTCTGATTCCACATTA\nforward_primer.f\treverse_primer.r\t177\t586\t409\tGGAGAAAGATTTCTCTTGAAGATCTTTTCTGTTCCACTTCAAACCTTCCTTCCCCTACTAAAGGGAATCTCCCAATTATTGCCGACGCTGGTGACCATGGGATTTTATCTTTCAAAGTTTCTGACCTGAAAGAAGATATACCCTCGCAAATATCGACGGCTAAGGAAGAGTCCTTCAGTGGTAATGAAGAAGAAGAAGAAGAAGAAGGTGATGACGATGATAAGATAACCCTTCAGGATTTTGTTTGTAATGAAAAGAACCAAAAAGAAATGGGTGAACAAAGAAATGACGTAAGCTCGTCTTCTTGGGTACAAACTGAGCTGTTGTTTCTTCTCCTAAAGGGAAGTATCGGGAGTAATGATACTCAAACAACACTGAGAAAACCAACCCTGTTTCTGATTCCACATTA"
+        expected_result = ""
+        actual_result = find_pcr_product(
+            primer_file="tests/test_data/primers/test_primers_1.fa",
+            sequence_file="tests/test_data/sequences/small_sequence.fa",
+            min_product_length=100,
+        )
+        assert expected_result == actual_result
+
+    def test_maximum_product_length(self) -> None:
+        expected_results = "forward_primer.f\treverse_primer.r\t177\t255\t78\tGGAGAAAGATTTCTCTTGAAGATCTTTTCTGTTCCACTTCAAACCTTCCTTCCCCTACTAAAGGGAATCTCCCAATTA\nforward_primer.f\treverse_primer.r\t528\t586\t58\tGGAGTAATGATACTCAAACAACACTGAGAAAACCAACCCTGTTTCTGATTCCACATTA"
         actual_result = find_pcr_product(
             primer_file="tests/test_data/primers/test_primers_1.fa",
             sequence_file="tests/test_data/sequences/single_test.fa",
-            min_product_length=150,
+            max_product_length=100,
         )
 
-        assert expected_result == actual_result
+        assert expected_results == actual_result
+
+    def test_product_length_range(self) -> None:
+        expected_results = "forward_primer.f\treverse_primer.r\t177\t255\t78\tGGAGAAAGATTTCTCTTGAAGATCTTTTCTGTTCCACTTCAAACCTTCCTTCCCCTACTAAAGGGAATCTCCCAATTA"
+        actual_results = find_pcr_product(
+            primer_file="tests/test_data/primers/test_primers_1.fa",
+            sequence_file="tests/test_data/sequences/single_test.fa",
+            min_product_length=75,
+            max_product_length=100,
+        )
+
+        assert expected_results == actual_results

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -133,3 +133,13 @@ class TestDesiredProductSize:
                 potential_product_size, min_product_length, max_product_length
             )
             assert actual == expected
+
+    def test_improper_limits(self) -> None:
+        min_product_length, max_product_length = 200, 100
+
+        with pytest.raises(ValueError):
+            desired_product_size(
+                20,
+                min_product_length=min_product_length,
+                max_product_length=max_product_length,
+            )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@ from typing import Iterator, List
 import pytest
 
 from ispcr.FastaSequence import FastaSequence
-from ispcr.utils import read_fasta, reverse_complement
+from ispcr.utils import desired_product_size, read_fasta, reverse_complement
 
 
 class TestReverseComplement:
@@ -58,3 +58,78 @@ class TestReaderUtils:
         actual_single_header = single_test_sequence.header
 
         assert expected_single_header == actual_single_header
+
+
+class TestDesiredProductSize:
+    def test_min_none_pass(self) -> None:
+        min_product_length, max_product_length = None, 200
+        potential_product_size = 150
+        expected = True
+        actual = desired_product_size(
+            potential_product_size, min_product_length, max_product_length
+        )
+
+        assert actual == expected
+
+    def test_min_none_fail(self) -> None:
+        min_product_length, max_product_length = None, 200
+        potential_product_size = 300
+        expected = False
+        actual = desired_product_size(
+            potential_product_size, min_product_length, max_product_length
+        )
+
+        assert actual == expected
+
+    def test_max_none_pass(self) -> None:
+        min_product_length, max_product_length = 100, None
+        potential_product_size = 150
+        expected = True
+        actual = desired_product_size(
+            potential_product_size, min_product_length, max_product_length
+        )
+
+        assert actual == expected
+
+    def test_max_none_fail(self) -> None:
+        min_product_length, max_product_length = 100, None
+        potential_product_size = 50
+        expected = False
+        actual = desired_product_size(
+            potential_product_size, min_product_length, max_product_length
+        )
+
+        assert actual == expected
+
+    def test_both_none_pass(self) -> None:
+        min_product_length, max_product_length = None, None
+        potential_product_sizes = [5, 50, 150, 250, 1000]
+        expected = True
+
+        for potential_product_size in potential_product_sizes:
+            actual = desired_product_size(
+                potential_product_size, min_product_length, max_product_length
+            )
+            assert actual == expected
+
+    def test_both_pass(self) -> None:
+        min_product_length, max_product_length = 75, 250
+        potential_product_sizes = [75, 100, 150, 250]
+        expected = True
+
+        for potential_product_size in potential_product_sizes:
+            actual = desired_product_size(
+                potential_product_size, min_product_length, max_product_length
+            )
+            assert actual == expected
+
+    def test_both_fail(self) -> None:
+        min_product_length, max_product_length = 75, 250
+        potential_product_sizes = [1, 50, 74, 251, 1000]
+        expected = False
+
+        for potential_product_size in potential_product_sizes:
+            actual = desired_product_size(
+                potential_product_size, min_product_length, max_product_length
+            )
+            assert actual == expected


### PR DESCRIPTION
## Description

Added support for a max product length parameter in the main functions. This involved refactoring the length checking segment of the PCR code into a new `desired_product_length` function.

## Checklist

- [x] Tests covering the new functionality have been added
- [x] Documentation has been updated OR the change is too minor to be documented
- [x] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
